### PR TITLE
fix degit link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # typescript-lib
 
-Clone this project template with [degit](https://github.com/Rich-Harris/typescript-lib):
+Clone this project template with [degit](https://github.com/Rich-Harris/degit):
 
 ```bash
 npx degit rich-harris/typescript-lib my-new-lib


### PR DESCRIPTION
I did the update in github's editor so I think it might've added a newline at the end of the file.